### PR TITLE
Refactor: update PromptIRModel to load settings from options.py

### DIFF
--- a/options.py
+++ b/options.py
@@ -6,6 +6,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--cuda', type=int, default=0)
 
 parser.add_argument('--epochs', type=int, default=120, help='maximum number of epochs to train the total model.')
+parser.add_argument('--warmup_epochs', type=int, default=15, help='number of epochs to warmup the learning rate to the given one')
 parser.add_argument('--batch_size', type=int,default=8,help="Batch size to use per GPU")
 parser.add_argument('--lr', type=float, default=2e-4, help='learning rate of encoder.')
 


### PR DESCRIPTION
Hello, I found that the `PromptIRModel` class in the `train.py` file had hardcoded values such as **lr=2e-4**, **max_epochs=120**, and others. In my opinion, these values should be replaced with the ones set in `options.py`. Therefore, I modified the `PromptIRModel` to load these parameters from `options.py` and added a new option called **warmup_epochs** in the `options.py`.